### PR TITLE
SCMOD-15298:Adding newer root certificate.

### DIFF
--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -19,6 +19,9 @@ FROM ${DOCKER_HUB_PUBLIC}/digitallyseamless/nodejs-bower-grunt:5
 
 # Download and compile v1.29 of tar
 # (Version 1.27.1 is included in the base image but it doesn't have the --exclude-vcs-ignores switch)
+RUN sed -i -e 's/mozilla\/DST_Root_CA_X3\.crt/!mozilla\/DST_Root_CA_X3\.crt/g' /etc/ca-certificates.conf
+RUN wget http://launchpadlibrarian.net/482351465/ca-certificates_20190110~12.04.1_all.deb
+RUN dpkg -i ca-certificates_20190110~12.04.1_all.deb
 RUN curl -sSL https://ftp.gnu.org/gnu/tar/tar-1.29.tar.gz | tar xzf - -C /usr/src/
 RUN cd /usr/src/tar-1.29/ && FORCE_UNSAFE_CONFIGURE=1 ./configure && make && make install
 


### PR DESCRIPTION
Jira => https://portal.digitalsafe.net/browse/SCMOD-15298.

DST Root CA X3 root certificate has expired as of September 30, 2021. Adding Letsencrypt newer root certificate ISRG Root X1. 