### PR TITLE
SCMOD-15298: Update to use opensuse-nodejs image

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 
     <groupId>com.github.cafapi</groupId>
     <artifactId>doc-site-compiler-image</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     
     <name>Doc Site Compiler image</name>

--- a/release-notes-2.0.0.md
+++ b/release-notes-2.0.0.md
@@ -1,7 +1,7 @@
 !not-ready-for-release!
 
-#### BBreaking Changes
-Move from a Debian-based image to an openSUSE-based image.
+#### Breaking Changes
+SCMOD-15298: Move from a Debian-based image to an openSUSE-based image.
 
 #### Version Number
 ${version-number}

--- a/release-notes-2.0.0.md
+++ b/release-notes-2.0.0.md
@@ -1,5 +1,8 @@
 !not-ready-for-release!
 
+#### BBreaking Changes
+Move from a Debian-based image to an openSUSE-based image.
+
 #### Version Number
 ${version-number}
 

--- a/release-notes-2.0.0.md
+++ b/release-notes-2.0.0.md
@@ -1,10 +1,10 @@
 !not-ready-for-release!
 
-#### Breaking Changes
-SCMOD-15298: Move from a Debian-based image to an openSUSE-based image.
-
 #### Version Number
 ${version-number}
+
+#### Breaking Changes
+- SCMOD-15298: Move from a Debian-based image to an openSUSE-based image.
 
 #### New Features
 

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -15,13 +15,13 @@
 #
 
 ARG DOCKER_HUB_PUBLIC=docker.io
-FROM ${DOCKER_HUB_PUBLIC}/digitallyseamless/nodejs-bower-grunt:5
+FROM ${DOCKER_HUB_PUBLIC}/cafapi/opensuse-nodejs10:latest
 
+RUN zypper install -y tar && \
+    zypper install -y gzip && \
+    zypper install -y -t pattern devel_basis
 # Download and compile v1.29 of tar
 # (Version 1.27.1 is included in the base image but it doesn't have the --exclude-vcs-ignores switch)
-RUN sed -i -e 's/mozilla\/DST_Root_CA_X3\.crt/!mozilla\/DST_Root_CA_X3\.crt/g' /etc/ca-certificates.conf
-RUN wget http://launchpadlibrarian.net/482351465/ca-certificates_20190110~12.04.1_all.deb
-RUN dpkg -i ca-certificates_20190110~12.04.1_all.deb
 RUN curl -sSL https://ftp.gnu.org/gnu/tar/tar-1.29.tar.gz | tar xzf - -C /usr/src/
 RUN cd /usr/src/tar-1.29/ && FORCE_UNSAFE_CONFIGURE=1 ./configure && make && make install
 

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -15,10 +15,9 @@
 #
 
 ARG DOCKER_HUB_PUBLIC=docker.io
-FROM ${DOCKER_HUB_PUBLIC}/cafapi/opensuse-nodejs10:latest
+FROM ${DOCKER_HUB_PUBLIC}/cafapi/opensuse-nodejs10:2
 
-RUN zypper install -y tar && \
-    zypper install -y gzip && \
+RUN zypper install -y gzip && \
     zypper install -y -t pattern devel_basis
 # Download and compile v1.29 of tar
 # (Version 1.27.1 is included in the base image but it doesn't have the --exclude-vcs-ignores switch)
@@ -27,12 +26,6 @@ RUN cd /usr/src/tar-1.29/ && FORCE_UNSAFE_CONFIGURE=1 ./configure && make && mak
 
 # Install Bower Artifactory integration
 RUN npm install -g bower-art-resolver
-
-# Add Tini
-ENV TINI_VERSION v0.14.0
-ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
-RUN chmod +x /tini
-ENTRYPOINT ["/tini", "--"]
 
 # Copy in the build script and make it the default command
 ENV TARGET_FILE=docs-site.tar.gz

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -21,7 +21,12 @@ RUN zypper install -y gzip && \
     zypper install -y -t pattern devel_basis
 
 # Install Bower & Bower Artifactory integration
-RUN npm install -g bower bower-art-resolver
+RUN npm install -g bower && \
+    echo '{ "allow_root": true }' > /root/.bowerrc && \
+    npm install -g bower-art-resolver
+
+# Define working directory
+WORKDIR /data
 
 # Copy in the build script and make it the default command
 ENV TARGET_FILE=docs-site.tar.gz

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -20,8 +20,8 @@ FROM ${DOCKER_HUB_PUBLIC}/cafapi/opensuse-nodejs10:2
 RUN zypper install -y gzip && \
     zypper install -y -t pattern devel_basis
 
-# Install Bower Artifactory integration
-RUN npm install -g bower-art-resolver
+# Install Bower & Bower Artifactory integration
+RUN npm install -g bower bower-art-resolver
 
 # Copy in the build script and make it the default command
 ENV TARGET_FILE=docs-site.tar.gz

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -19,10 +19,6 @@ FROM ${DOCKER_HUB_PUBLIC}/cafapi/opensuse-nodejs10:2
 
 RUN zypper install -y gzip && \
     zypper install -y -t pattern devel_basis
-# Download and compile v1.29 of tar
-# (Version 1.27.1 is included in the base image but it doesn't have the --exclude-vcs-ignores switch)
-RUN curl -sSL https://ftp.gnu.org/gnu/tar/tar-1.29.tar.gz | tar xzf - -C /usr/src/
-RUN cd /usr/src/tar-1.29/ && FORCE_UNSAFE_CONFIGURE=1 ./configure && make && make install
 
 # Install Bower Artifactory integration
 RUN npm install -g bower-art-resolver

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -19,6 +19,9 @@ FROM ${DOCKER_HUB_PUBLIC}/digitallyseamless/nodejs-bower-grunt:5
 
 # Download and compile v1.29 of tar
 # (Version 1.27.1 is included in the base image but it doesn't have the --exclude-vcs-ignores switch)
+RUN sed -i -e 's/mozilla\/DST_Root_CA_X3\.crt/!mozilla\/DST_Root_CA_X3\.crt/g' /etc/ca-certificates.conf
+RUN wget http://launchpadlibrarian.net/482351465/ca-certificates_20190110~12.04.1_all.deb
+RUN dpkg -i ca-certificates_20190110~12.04.1_all.deb
 RUN curl -sSL https://ftp.gnu.org/gnu/tar/tar-1.29.tar.gz | tar xzf - -C /usr/src/
 RUN cd /usr/src/tar-1.29/ && FORCE_UNSAFE_CONFIGURE=1 ./configure && make && make install
 

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -17,8 +17,8 @@
 ARG DOCKER_HUB_PUBLIC=docker.io
 FROM ${DOCKER_HUB_PUBLIC}/cafapi/opensuse-nodejs10:2
 
-RUN zypper install -y gzip && \
-    zypper install -y -t pattern devel_basis
+RUN zypper -n install gzip && \
+    zypper -n install -t pattern devel_basis
 
 # Install Bower & Bower Artifactory integration
 RUN npm install -g bower && \


### PR DESCRIPTION
Jira => https://portal.digitalsafe.net/browse/SCMOD-15298.

Updating Dockerfile to use cafapi/opensuse-nodejs10:latest image.